### PR TITLE
add `status` and `ai_closure_type` to sessions stream

### DIFF
--- a/tap_opencx/schemas.py
+++ b/tap_opencx/schemas.py
@@ -37,6 +37,18 @@ sessions_schema = PropertiesList(
             ),
         ),
     ),
+    Property(
+        "status",
+        StringType,
+        description="current status of the session",
+        allowed_values=["open", "closed_resolved", "closed_unresolved"],
+    ),
+    Property(
+        "ai_closure_type",
+        StringType,
+        description="how the AI closed the session, null if not closed by AI",
+        allowed_values=["assumed_resolved", "handed_off", "resolved"],
+    ),
     Property("created_at", DateTimeType, description="session created timestamp (ISO 8601)"),
     Property("updated_at", DateTimeType, description="session updated timestamp (ISO 8601)"),
 ).to_dict()

--- a/tap_opencx/schemas.py
+++ b/tap_opencx/schemas.py
@@ -41,13 +41,11 @@ sessions_schema = PropertiesList(
         "status",
         StringType,
         description="current status of the session",
-        allowed_values=["open", "closed_resolved", "closed_unresolved"],
     ),
     Property(
         "ai_closure_type",
         StringType,
         description="how the AI closed the session, null if not closed by AI",
-        allowed_values=["assumed_resolved", "handed_off", "resolved"],
     ),
     Property("created_at", DateTimeType, description="session created timestamp (ISO 8601)"),
     Property("updated_at", DateTimeType, description="session updated timestamp (ISO 8601)"),


### PR DESCRIPTION
## What

Adds two new fields to the `sessions` stream schema that are returned by the open.cx chat sessions API:

- `status`: current status of the session (`open`, `closed_resolved`, `closed_unresolved`)
- `ai_closure_type`: how the AI closed the session (`assumed_resolved`, `handed_off`, `resolved`) — nullable

## Why

These fields were missing from the schema, meaning they were silently dropped during sync. Capturing them enables downstream analysis of session outcomes and AI closure behaviour.

## References

- [open.cx API docs — status field](https://docs.open.cx/api-reference/chat-sessions/get#response-status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)