### PR TITLE
Add `summary` to sessions stream

### DIFF
--- a/tap_opencx/schemas.py
+++ b/tap_opencx/schemas.py
@@ -47,6 +47,11 @@ sessions_schema = PropertiesList(
         StringType,
         description="how the AI closed the session, null if not closed by AI",
     ),
+    Property(
+        "summary",
+        StringType,
+        description="AI-generated summary of the conversation",
+    ),
     Property("created_at", DateTimeType, description="session created timestamp (ISO 8601)"),
     Property("updated_at", DateTimeType, description="session updated timestamp (ISO 8601)"),
 ).to_dict()


### PR DESCRIPTION
# What
Adding the new `summary` field to the sessions stream schema

# Why
This is a new field that stores a short summary of all AI-resolved conversations. Capturing this enables analysis of session outcomes and customer contact reasons.

## References
[slack request to opencx](https://ticketswap.slack.com/archives/C08EHCG60DD/p1782899811806209)
[open.cx API docs](https://docs.open.cx/api-reference/chat-sessions/get#response-summary-one-of-0)